### PR TITLE
Switch dune.xyz -> dune.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </h1>
 
 <div align="center">
-A lightweight (unofficial) Python SDK for <a href=https://dune.xyz/home> Dune.xyz</a>
+A lightweight (unofficial) Python SDK for <a href=https://dune.com/home> Dune.com</a>
 <br>
 
 [Installation](#installation) •
@@ -30,7 +30,7 @@ pip install dunebuggy
 
 ### Retrieving a public query
 
-To retrieve a query, all we'll need is the `query_id` for the public query we're interested in. In the below example we can take a look at the popular ["Custom NFT Floor Tracker" query by @smaroo](https://dune.xyz/queries/83579) (The `query_id` below can be found in the URL).
+To retrieve a query, all we'll need is the `query_id` for the public query we're interested in. In the below example we can take a look at the popular ["Custom NFT Floor Tracker" query by @smaroo](https://dune.com/queries/83579) (The `query_id` below can be found in the URL).
 
 ```python
 from dunebuggy import Dune
@@ -200,7 +200,7 @@ print(custom_query.df.head())
 
 ### Creating a new query
 
-`dunebuggy` also allows you to create a new using an existing Dune.xyz account.To login just need to pass in your username/password into the `Dune` object.
+`dunebuggy` also allows you to create a new using an existing Dune.com account.To login just need to pass in your username/password into the `Dune` object.
 
 You can verify your login by inspecting your Dune `user_id`
 

--- a/notebooks/basic_example.ipynb
+++ b/notebooks/basic_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Dunebuggy\n",
     "---\n",
-    "A lightweight (unofficial) Python SDK for Dune.xyz\n",
+    "A lightweight (unofficial) Python SDK for Dune.com\n",
     "\n",
     "## Installation\n",
     "\n",
@@ -23,7 +23,7 @@
     "\n",
     "### Retrieving a public query\n",
     "\n",
-    "To retrieve a query, all we'll need is the ```query_id``` for the public query we're interested in. In the below example we can take a look at the popular [\"Custom NFT Floor Tracker\" query by @smaroo](https://dune.xyz/queries/83579) (The ```query_id``` below can be found in the URL)."
+    "To retrieve a query, all we'll need is the ```query_id``` for the public query we're interested in. In the below example we can take a look at the popular [\"Custom NFT Floor Tracker\" query by @smaroo](https://dune.com/queries/83579) (The ```query_id``` below can be found in the URL)."
    ]
   },
   {
@@ -203,7 +203,7 @@
    "source": [
     "### Creating a new query\n",
     "\n",
-    "Dunebuggy also allows you to create a new using an existing Dune.xyz account.You'll just need to pass in your username/password into the ```Dune``` object in order to login. After logging in, you should be able to retrieve your ```user_id```"
+    "Dunebuggy also allows you to create a new using an existing Dune.com account.You'll just need to pass in your username/password into the ```Dune``` object in order to login. After logging in, you should be able to retrieve your ```user_id```"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "dunebuggy"
 version = "1.0.6"
-description = "A lightweight (unofficial) Python SDK for Dune.xyz"
+description = "A lightweight (unofficial) Python SDK for Dune.com"
 authors = ["rysuds <ryan.sudhakaran@gmail.com>"]
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
# Summary
- Switching from `Dune.xyz` -> `Dune.com`
- Ran `grep -RiIl '.xyz' | xargs sed -i '' 's/\.xyz/\.com/g'`

# Tests
- Tested that all hyperlinks work